### PR TITLE
Fix typo: word inside underscores not render like italic if there are…

### DIFF
--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -464,7 +464,7 @@ Al mover el `v-if` a un elemento contenedor, ya no estamos comprobando `shouldSh
 
 **Para las aplicaciones, los estilos, en un componente `App` de nivel superior y en los componentes de "layout" pueden ser globales, pero todos los demás componentes siempre deben ser _scoped_**
 
-Esto es relevante sólo a [componentes single-file](../guide/single-file-components.html). _No_ requiere que se use el atributo [`scoped`](https://vue-loader.vuejs.org/en/features/scoped-css.html). El "scoping" podría ser a través de [CSS modules](https://vue-loader.vuejs.org/en/features/css-modules.html), una estrategia basada en clases como [BEM](http://getbem.com/), ú otra biblioteca/convención.
+Esto es relevante sólo a [componentes single-file](../guide/single-file-components.html). *No* requiere que se use el atributo [`scoped`](https://vue-loader.vuejs.org/en/features/scoped-css.html). El "scoping" podría ser a través de [CSS modules](https://vue-loader.vuejs.org/en/features/css-modules.html), una estrategia basada en clases como [BEM](http://getbem.com/), ú otra biblioteca/convención.
 
 **Para las bibliotecas de componentes, sin embargo, se debería implementar una estrategia basada en clases en vez de usar el atributo `scoped`.**
 


### PR DESCRIPTION
… only two letters between underscores

<img width="640" alt="Captura de pantalla 2019-10-21 a las 14 57 34" src="https://user-images.githubusercontent.com/28918805/67207157-44f56680-f413-11e9-8e7c-f786f601678f.png">
