### PR TITLE
docs: update Scrimba link according to original docs

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -32,7 +32,7 @@ o con:
 
 La [página de instalación](installation.html) proporciona más opciones de instalación de Vue. Nota: **No** recomendamos que los principiantes comiencen con `vue-cli`, especialmente si aún no están familiarizados con las herramientas de _build_ basadas en Node.js.
 
-Si prefiere algo más interactivo, también puede ver [esta serie de tutoriales en Scrimba](https://scrimba.com/playlist/pXKqta), que le ofrece una combinación de _screencast_ y _playground_ de código con los que puede pausar y jugar en cualquier momento.
+Si prefiere algo más interactivo, también puede ver [esta serie de tutoriales en Scrimba](https://scrimba.com/g/gvuedocs), que le ofrece una combinación de _screencast_ y _playground_ de código con los que puede pausar y jugar en cualquier momento.
 
 ## Renderización Declarativa
 


### PR DESCRIPTION
The link to the Scrimba tutorial has changed. Evan You merged in the updated link to the original Vue docs earlier today, so I created this PR so that the Russian translation can stay up to date.

Here's the original PR: vuejs/vuejs.org#2368