### PR TITLE
changing word to its correct translation

### DIFF
--- a/src/v2/guide/computed.md
+++ b/src/v2/guide/computed.md
@@ -155,7 +155,7 @@ Mucho mejor, ¿no?
 
 ### Setter Computado
 
-Las propiedades calculadas son, de forma predeterminada solo get, pero también puede proporcionar un set cuando lo necesite:
+Las propiedades computadas son, de forma predeterminada solo get, pero también puede proporcionar un set cuando lo necesite:
 
 ``` js
 // ...


### PR DESCRIPTION
A Computed  word was changed to its correct translation: computadas. 
Most people can be confused with incorrect translation, as well as losing all context.