### PR TITLE
Cambio de palabra Objecto

### DIFF
--- a/src/v2/guide/components-props.md
+++ b/src/v2/guide/components-props.md
@@ -105,7 +105,7 @@ En los dos ejemplos anteriores, pasamos valores de tipo cadena de texto, pero _c
 <blog-post v-bind:comment-ids="post.commentIds"></blog-post>
 ```
 
-### Pasando un Objecto
+### Pasando un Objeto
 
 ```html
 <!-- Aunque el objeto es estático, necesitamos v-bind para decirle a Vue que -->


### PR DESCRIPTION
Dice "Objecto", debería decir "Objeto"