### PR TITLE
Update link in ecosystem dropdown

### DIFF
--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -5,7 +5,7 @@
     <li><ul>
       <li><a href="https://forum.vuejs.org/" class="nav-link" target="_blank">Foro</a></li>
       <li><a href="https://chat.vuejs.org/" class="nav-link" target="_blank">Chat</a></li>
-      <li><a href="https://www.vuemeetups.org/" class="nav-link" target="_blank">Meetups</a></li>
+      <li><a href="https://events.vuejs.org/meetups/" class="nav-link" target="_blank">Meetups</a></li>
     </ul></li>
     <li><h4>Herramientas</h4></li>
     <li>


### PR DESCRIPTION
https://www.vuemeetups.org/ was broken and after checking vuejs.org in other languages I've to change it accordingly to the others to https://events.vuejs.org/meetups/