### PR TITLE
fix: camelCase for template syntax

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -59,7 +59,7 @@ Dentro de los bloques `v-for` tenemos acceso completo a las propiedades del ámb
 ``` html
 <ul id="example-2">
   <li v-for="(item, index) in items">
-    {{ MensajePadre }} - {{ index }} - {{ item.mensaje }}
+    {{ mensajePadre }} - {{ index }} - {{ item.mensaje }}
   </li>
 </ul>
 ```


### PR DESCRIPTION
Editing the example in the "Renderizado de lista
Mapeando una matriz a elementos con v-for" section for spanish translation.